### PR TITLE
Updated the github repo reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
     localBiblio: ccg.localBiblio,
     xref: "web-platform",
     github: {
-      repoURL: "https://github.com/w3c/did-core/",
+      repoURL: "https://github.com/w3c/did-cbor-note/",
       branch: "main"
     },
     includePermalinks: false,


### PR DESCRIPTION
It pointed at the did-core repository, it should point at this repository...


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/did-cbor-note/pull/1.html" title="Last updated on May 17, 2021, 6:42 AM UTC (b1c4186)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/did-cbor-note/1/4167198...b1c4186.html" title="Last updated on May 17, 2021, 6:42 AM UTC (b1c4186)">Diff</a>